### PR TITLE
Remove configuration for retired services

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # Basic Vue and Vuex Store
 
-[![Greenkeeper badge](https://badges.greenkeeper.io/alpersonalwebsite/basic-vue-vuex.svg)](https://greenkeeper.io/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-brightgreen.svg)](https://opensource.org/licenses/MIT)
 
 An easy, basic and raw (no styles attached) example of **HOW to** implement a `Vuex`


### PR DESCRIPTION
Housekeeping only, no code or dependency touched.

Removed: README-badge

Greenkeeper shut down and WhiteSource Bolt is now Mend under a different integration, so
neither `.whitesource` nor `greenkeeper.json` is read by anything.

The Greenkeeper badge, where present, is worse than merely stale. Its image is
**byte-identical** for this repository and for one that does not exist, both rendering
"Greenkeeper - Move to Snyk", so it conveys nothing about this project. Verified by
fetching both and comparing.